### PR TITLE
elastic: add timestamp format option to config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -125,6 +125,11 @@ inputs:
         must_have_fields:
           # - @timestamp
 
+        # A timestamp format (ie. strict_date_time_no_millis) can be specified, and will be
+        # added to search queries when appropriate.  It's advised to leave this unset unless
+        # you have reason to set a specific format.
+        # timestamp_format:
+
         # Field names should contain field paths that contain required telemetry data.
         # They can be left empty if index_schema is set. Similarly to search terms, you can
         # override some of all of mappings by setting the fields below.
@@ -145,6 +150,10 @@ inputs:
         indices:
           # - filebeat-*
         index_schema: ecs
+        # A timestamp format (ie. strict_date_time_no_millis) can be specified, and will be
+        # added to search queries when appropriate.  It's advised to leave this unset unless
+        # you have reason to set a specific format.
+        # timestamp_format:
         field_names:
           # Event timestamp (required).
           # timestamp:
@@ -168,6 +177,10 @@ inputs:
         indices:
           # - filebeat-*
         index_schema: ecs
+        # A timestamp format (ie. strict_date_time_no_millis) can be specified, and will be
+        # added to search queries when appropriate.  It's advised to leave this unset unless
+        # you have reason to set a specific format.
+        # timestamp_format:
         field_names:
           # Event timestamp (required).
           # timestamp:
@@ -189,6 +202,10 @@ inputs:
         indices:
           # - filebeat-*
         index_schema: ecs
+        # A timestamp format (ie. strict_date_time_no_millis) can be specified, and will be
+        # added to search queries when appropriate.  It's advised to leave this unset unless
+        # you have reason to set a specific format.
+        # timestamp_format:
         field_names:
           # Event timestamp (required).
           # timestamp:

--- a/elastic/config.go
+++ b/elastic/config.go
@@ -126,9 +126,10 @@ type FieldNamesConfig struct {
 	EventIngested string `yaml:"event_ingested"`
 
 	// DNS, IP, HTTP, TLS
-	Timestamp string    `yaml:"timestamp"`
-	SrcIP     FieldPath `yaml:"src_ip"` // required
-	SrcPort   FieldPath `yaml:"src_port"`
+	Timestamp       string    `yaml:"timestamp"`
+	TimestampFormat string    `yaml:"timestamp_format"`
+	SrcIP           FieldPath `yaml:"src_ip"` // required
+	SrcPort         FieldPath `yaml:"src_port"`
 
 	// DNS
 	Query FieldPath `yaml:"query"` // required

--- a/elastic/config.go
+++ b/elastic/config.go
@@ -126,10 +126,9 @@ type FieldNamesConfig struct {
 	EventIngested string `yaml:"event_ingested"`
 
 	// DNS, IP, HTTP, TLS
-	Timestamp       string    `yaml:"timestamp"`
-	TimestampFormat string    `yaml:"timestamp_format"`
-	SrcIP           FieldPath `yaml:"src_ip"` // required
-	SrcPort         FieldPath `yaml:"src_port"`
+	Timestamp string    `yaml:"timestamp"`
+	SrcIP     FieldPath `yaml:"src_ip"` // required
+	SrcPort   FieldPath `yaml:"src_port"`
 
 	// DNS
 	Query FieldPath `yaml:"query"` // required
@@ -166,15 +165,16 @@ type FieldNamesConfig struct {
 // running a periodic search to retrieve telemetry,
 // extract required fields and send data to AlphaSOC API.
 type SearchConfig struct {
-	EventType      client.EventType  `yaml:"event_type"`
-	Indices        []string          `yaml:"indices"`
-	IndexSchema    IndexSchema       `yaml:"index_schema"`
-	PollInterval   float64           `yaml:"poll_interval"`
-	BatchSize      int               `yaml:"batch_size"`
-	PITKeepAlive   float64           `yaml:"pit_keep_alive"`
-	MustHaveFields []string          `yaml:"must_have_fields"`
-	SearchTerm     string            `yaml:"search_term"`
-	FieldNames     *FieldNamesConfig `yaml:"field_names"`
+	EventType       client.EventType  `yaml:"event_type"`
+	Indices         []string          `yaml:"indices"`
+	IndexSchema     IndexSchema       `yaml:"index_schema"`
+	PollInterval    float64           `yaml:"poll_interval"`
+	BatchSize       int               `yaml:"batch_size"`
+	PITKeepAlive    float64           `yaml:"pit_keep_alive"`
+	MustHaveFields  []string          `yaml:"must_have_fields"`
+	SearchTerm      string            `yaml:"search_term"`
+	TimestampFormat string            `yaml:"timestamp_format"`
+	FieldNames      *FieldNamesConfig `yaml:"field_names"`
 
 	// Final field names, merged defaults with user-provided.
 	finalFieldNames *FieldNamesConfig

--- a/elastic/search_query.go
+++ b/elastic/search_query.go
@@ -7,7 +7,8 @@ import (
 
 // DocRangeField is used in DocRange
 type DocRangeField struct {
-	Gte string `json:"gte"`
+	Gte    string `json:"gte"`
+	Format string `json:"format,omitempty"`
 }
 
 // DocRange is used in SearchQuery.
@@ -76,7 +77,11 @@ func (ec *EventsCursor) searchQuery() ([]byte, error) {
 	if ec.newestIngested.IsZero() {
 		docrange.Range[fn.EventIngested] = DocRangeField{Gte: "now-5m"}
 	} else {
-		docrange.Range[fn.EventIngested] = DocRangeField{Gte: ec.newestIngested.Format(time.RFC3339Nano)}
+		drf := DocRangeField{Gte: ec.newestIngested.Format(time.RFC3339Nano)}
+		if ec.search.FieldNames != nil && len(ec.search.FieldNames.TimestampFormat) > 0 {
+			drf.Format = ec.search.FieldNames.TimestampFormat
+		}
+		docrange.Range[fn.EventIngested] = drf
 	}
 
 	drjson, _ := json.Marshal(docrange)

--- a/elastic/search_query.go
+++ b/elastic/search_query.go
@@ -78,8 +78,13 @@ func (ec *EventsCursor) searchQuery() ([]byte, error) {
 		docrange.Range[fn.EventIngested] = DocRangeField{Gte: "now-5m"}
 	} else {
 		drf := DocRangeField{Gte: ec.newestIngested.Format(time.RFC3339Nano)}
-		if ec.search.FieldNames != nil && len(ec.search.FieldNames.TimestampFormat) > 0 {
-			drf.Format = ec.search.FieldNames.TimestampFormat
+		// Add a timestamp format to the query if configured.  Added in response to a
+		// case where the ingested timestamp lacked milliseconds.  The search query,
+		// to prevent a date field parse error, needed an explicitly set timestamp
+		// format of 'strict_date_time_no_millis'.  Thus it was decided to make this
+		// configurable.
+		if ec.search.TimestampFormat != "" {
+			drf.Format = ec.search.TimestampFormat
 		}
 		docrange.Range[fn.EventIngested] = drf
 	}


### PR DESCRIPTION
To allow for modifying the timestamp format in search queries:

         field_names:
         ...
           timestamp_format: strict_date_time_no_millis
           event_ingested: '@timestamp'

Which reults in a search query having the following filter:

      "filter": [
        {
          "range": {
            "@timestamp": {
              "gte": "0001-01-01T00:00:00Z",
              "format": "strict_date_time_no_millis"
            }
          }
        }
      ]