### PR TITLE
elastic: append root_cause array to error message

### DIFF
--- a/elastic/errors.go
+++ b/elastic/errors.go
@@ -11,6 +11,19 @@ import (
 // ErrQueryTimeout is returned when the search query has timed out.
 var ErrQueryTimeout = errors.New("query timeout")
 
+// dumpRootCauses returns a string representation of all root_cause entries as:
+//   "type1: reason1; type2: reason2; ...; typeN: reasonN"
+func dumpRootCauses(rcs []interface{}) string {
+	var rcsStr string
+	for _, rc := range rcs {
+		rcsStr += fmt.Sprintf(
+			"; %s: %s",
+			rc.(map[string]interface{})["type"],
+			rc.(map[string]interface{})["reason"])
+	}
+	return rcsStr
+}
+
 // IsAPIError checks if an es response contains an error.
 // If so, it decodes the body and returns the error.
 func IsAPIError(res *esapi.Response) error {
@@ -23,6 +36,13 @@ func IsAPIError(res *esapi.Response) error {
 		return err
 	}
 
+	if e["error"].(map[string]interface{})["root_cause"] != nil {
+		return fmt.Errorf("[%s] %s: %s%s",
+			res.Status(),
+			e["error"].(map[string]interface{})["type"],
+			e["error"].(map[string]interface{})["reason"],
+			dumpRootCauses(e["error"].(map[string]interface{})["root_cause"].([]interface{})))
+	}
 	return fmt.Errorf("[%s] %s: %s",
 		res.Status(),
 		e["error"].(map[string]interface{})["type"],


### PR DESCRIPTION
Should allow for better identification of certain types of search failures.

ie: 13 shards; date parse failure

`time="2022-03-21T10:23:31+01:00" level=error msg="fetch events: search api error: [400 Bad Request] search_phase_execution_exception: all shards failed; parse_exception: failed to parse date field [2022-03-21T10:23:31.253419+01:00] with format [strict_date_time_no_millis]; parse_exception: failed to parse date field [2022-03-21T10:23:31.253419+01:00] with format [strict_date_time_no_millis]; parse_exception: failed to parse date field [2022-03-21T10:23:31.253419+01:00] with format [strict_date_time_no_millis]; parse_exception: failed to parse date field [2022-03-21T10:23:31.253419+01:00] with format [strict_date_time_no_millis]; parse_exception: failed to parse date field [2022-03-21T10:23:31.253419+01:00] with format [strict_date_time_no_millis]; parse_exception: failed to parse date field [2022-03-21T10:23:31.253419+01:00] with format [strict_date_time_no_millis]; parse_exception: failed to parse date field [2022-03-21T10:23:31.253419+01:00] with format [strict_date_time_no_millis]; parse_exception: failed to parse date field [2022-03-21T10:23:31.253419+01:00] with format [strict_date_time_no_millis]; parse_exception: failed to parse date field [2022-03-21T10:23:31.253419+01:00] with format [strict_date_time_no_millis]; parse_exception: failed to parse date field [2022-03-21T10:23:31.253419+01:00] with format [strict_date_time_no_millis]; parse_exception: failed to parse date field [2022-03-21T10:23:31.253419+01:00] with format [strict_date_time_no_millis]; parse_exception: failed to parse date field [2022-03-21T10:23:31.253419+01:00] with format [strict_date_time_no_millis]; parse_exception: failed to parse date field [2022-03-21T10:23:31.253419+01:00] with format [strict_date_time_no_millis]" name=ip-001`