### PR TITLE
alerts: introduce NetworkWriter and handle reconnect on net errors

### DIFF
--- a/alerts/graylog_writer.go
+++ b/alerts/graylog_writer.go
@@ -23,7 +23,7 @@ type GraylogWriter struct {
 func NewGraylogWriter(uri string, level int) (*GraylogWriter, error) {
 	g, err := gelf.New(uri)
 	if err != nil {
-		return nil, fmt.Errorf("connect to graylog send input failed: %s", err)
+		return nil, fmt.Errorf("failed creating graylog writer: %s", err)
 	}
 
 	hostname, _ := os.Hostname()
@@ -69,6 +69,10 @@ func (w *GraylogWriter) Write(event *Event) error {
 		}
 	}
 	return nil
+}
+
+func (w *GraylogWriter) Connect() error {
+	return w.g.Connect()
 }
 
 // Close closes a connecion with the graylog server.

--- a/alerts/writer.go
+++ b/alerts/writer.go
@@ -16,6 +16,12 @@ type Writer interface {
 	Write(*Event) error
 }
 
+type NetworkWriter interface {
+	Writer
+	Connect() error
+	Close() error
+}
+
 type Formatter interface {
 	Format(*Event) ([][]byte, error)
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -111,7 +111,7 @@ func New(c client.Client, cfg *config.Config) (*Executor, error) {
 			if err != nil {
 				return nil, err
 			}
-			e.alertsPoller.AddWriter(graylogWriter)
+			e.alertsPoller.AddNetWriter(graylogWriter)
 		}
 
 		if cfg.Outputs.Syslog.IP != "" {
@@ -125,7 +125,7 @@ func New(c client.Client, cfg *config.Config) (*Executor, error) {
 			if err != nil {
 				return nil, err
 			}
-			e.alertsPoller.AddWriter(syslogWriter)
+			e.alertsPoller.AddNetWriter(syslogWriter)
 		}
 	}
 


### PR DESCRIPTION
This commit aims to reconnect to graylog and syslog servers when
network errors are encountered.